### PR TITLE
Upgrade Golangci-lint to v1.50.0

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -122,6 +122,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.48.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.50.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/releases/tag/v1.50.0

Related to: https://github.com/test-network-function/cnf-certification-test/pull/604