### PR TITLE
Upgrade Go to v1.20.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/test-network-function/l2discovery-dump
 
-go 1.19
+go 1.20
 
 require (
 	github.com/openshift/ptp-operator v0.0.0-20220922002031-4e588c96d5d6


### PR DESCRIPTION
Release Notes: https://tip.golang.org/doc/go1.20

Related to: https://github.com/test-network-function/cnf-certification-test/pull/873